### PR TITLE
Go instrumentation tool: More README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ If you have any questions, or to execute our corporate CLA, required if your con
 
 ## License
 This Go instrumentation tool is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
->The Go instrumentation tool also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.
+>This tool also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For detailed instructions on how to generate instrumentation suggestions, see ou
 This is an experimental product, and New Relic is not offering official support at the moment. Please create issues in Github if you are encountering a problem that you're unable to resolve. When creating issues, its vital to include as much of the prompted for information as possible. This enables us to get to the root cause of the issue much more quickly. Please also make sure to search existing issues before creating a new one.
 
 ## Contributing
-We encourage your contributions to improve the Go instrumentation tool! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
+We encourage your contributions! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
 If you have any questions, or to execute our corporate CLA, required if your contribution is on behalf of a company, please drop us an email at opensource@newrelic.com.
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Go instrumentation tool
 Go is a compiled language with an opaque runtime, making it unable to support automatic instrumentation like other languages. For this reason, the New Relic Go agent is designed as an SDK. Since the Go agent is an SDK, it requires more manual work to set up than agents for languages that support automatic instrumentation.
 
-In an effort to reduce that manual effort, the Go agent team created an easy instrumentation tool for Go that is currently in preview. This tool will do most of the work for you by suggesting changes to your source code that instrument your application with the New Relic Go agent.
+In an effort to make instrumentation easier, the Go agent team created an instrumentation tool that is currently in preview. This tool does most of the work for you by suggesting changes to your source code that instrument your application with the New Relic Go agent.
 
 To get started, check out this four-minute video, or skip down to [How it works](#how-it-works).
 
@@ -17,11 +17,10 @@ This project, its code, and the UX are under heavy development, and should be ex
 
 ## How it works
 
-This tool will not interfere with your application's operation, and it doesn't make any changes to your code directly. Here's what happens:
+This tool doesn't interfere with your application's operation, and it doesn't make any changes to your code directly. Here's what happens when you run the tool:
 
-* It analyzes your source code and identifies opportunities to instrument it.
-* It suggests changes to your code that use the New Relic Go agent SDK to capture telemetry data.
-* You review those sugestions that are inserted in a `.diff` file and decide which changes to apply to your source code.
+* It analyzes your code and suggests changes that allow the Go agent to capture telemetry data. 
+* You review the changes in the .diff file and decide which changes to add to your source code.
 
 As part of the analysis, this tool may invoke `go get` or other Go language toolchain commands which may modify your `go.mod` file, but not your actual source code.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://opensource.newrelic.com/oss-category/#new-relic-experimental"><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/dark/Experimental.png"><source media="(prefers-color-scheme: light)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png"><img alt="New Relic Open Source experimental project banner." src="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png"></picture></a>
 
-# Go instrumentation tool
+# Go easy instrumentation [![codecov](https://codecov.io/gh/newrelic/go-easy-instrumentation/graph/badge.svg?token=0qFy6WGpL8)](https://codecov.io/gh/newrelic/go-easy-instrumentation)
 Go is a compiled language with an opaque runtime, making it unable to support automatic instrumentation like other languages. For this reason, the New Relic Go agent is designed as an SDK. Since the Go agent is an SDK, it requires more manual work to set up than agents for languages that support automatic instrumentation.
 
 In an effort to make instrumentation easier, the Go agent team created an instrumentation tool that is currently in preview. This tool does most of the work for you by suggesting changes to your source code that instrument your application with the New Relic Go agent.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Before you start the installation steps below, make sure you have a version of G
 
 1. Clone this repository to a directory on your system. For example:
     ```sh
-    git clone .../go-agent-pre-instrumentation
+    git clone .../go-easy-instrumentation.git
     ```
 2. Go into that directory:
     ```sh
-    cd go-agent-pre-instrumentation
+    cd go-easy-instrumentation
     ```
 3. Resolve any third-party dependencies:
     ```sh

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Before you start the installation steps below, make sure you have a version of G
 For detailed instructions on how to generate instrumentation suggestions, see our documentation at [docs.newrelic.com](https://docs/apm/agents/go-agent/installation/install-automation-new-relic-go/#generate-suggestions).
 
 ## Support
-This is an experimental product, and New Relic is not offering official support at the moment. Please create issues in Github if you are encountering a problem that you're unable to resolve. When creating issues, its vital to include as much of the prompted for information as possible. This enables us to get to the root cause of the issue much more quickly. Please also make sure to search existing issues before creating a new one.
+This is an experimental product, and New Relic is not offering official support at the moment. Please create issues in Github if you are encountering a problem that you're unable to resolve. When creating issues, its vital that you include as much of the requested information as possible. This enables us to get to the root cause of the issue much more quickly. Please also make sure to search existing issues before creating a new one.
 
 ## Contributing
 We encourage your contributions! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.

--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ The scope of what this tool can instrument in your application is limited to the
 Before you start the installation steps below, make sure you have a version of Go installed that is within the support window for the current [Go programming language lifecycle](https://endoflife.date/go).
 
 1. Clone this repository to a directory on your system. For example:
-        ```sh
-        git clone .../go-agent-pre-instrumentation
-        ```
+    ```sh
+    git clone .../go-agent-pre-instrumentation
+    ```
 2. Go into that directory:
-        ```sh
-        cd go-agent-pre-instrumentation
-        ```
+    ```sh
+    cd go-agent-pre-instrumentation
+    ```
 3. Resolve any third-party dependencies:
-        ```sh
-        go mod tidy
-        ```
+    ```sh
+    go mod tidy
+    ```
 ## Generate instrumentation suggestions
 
 For detailed instructions on how to generate instrumentation suggestions, see our documentation at [docs.newrelic.com](https://docs/apm/agents/go-agent/installation/install-automation-new-relic-go/#generate-suggestions).

--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ If you have any questions, or to execute our corporate CLA, required if your con
 
 
 ## License
-This Go instrumentation tool is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
+Go easy instrumentation is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
 >This tool also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 <a href="https://opensource.newrelic.com/oss-category/#new-relic-experimental"><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/dark/Experimental.png"><source media="(prefers-color-scheme: light)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png"><img alt="New Relic Open Source experimental project banner." src="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png"></picture></a>
 
-# Go Easy Instrumentation [![codecov](https://codecov.io/gh/newrelic/go-easy-instrumentation/graph/badge.svg?token=0qFy6WGpL8)](https://codecov.io/gh/newrelic/go-easy-instrumentation)
-Go is a compiled language with an opaque runtime, making it unable to support automatic instrumentation like other languages. For this reason, the New Relic Go agent is designed as an SDK. Since the Go agent is an SDK, it requires more manual work to set up than agents for languages that support automatic instrumentation. 
+# Go instrumentation tool
+Go is a compiled language with an opaque runtime, making it unable to support automatic instrumentation like other languages. For this reason, the New Relic Go agent is designed as an SDK. Since the Go agent is an SDK, it requires more manual work to set up than agents for languages that support automatic instrumentation.
 
-In an effort to reduce that manual effort, the Go agent team created the tool Go Easy Instrumentation that is currently in preview. This tool will do most of the work for you by suggesting changes to your source code that instrument your application with the New Relic Go agent.
+In an effort to reduce that manual effort, the Go agent team created an easy instrumentation tool for Go that is currently in preview. This tool will do most of the work for you by suggesting changes to your source code that instrument your application with the New Relic Go agent.
+
+To get started, check out this four-minute video, or skip down to [How it works](#how-it-works).
 
 [![asciicast](https://asciinema.org/a/r0Il7o2eMiZaLKHIlew3IL2nx.svg)](https://asciinema.org/a/r0Il7o2eMiZaLKHIlew3IL2nx)
 
 ## Preview Notice
 
-This feature is currently provided as part of a preview and is subject to our New Relic Experimental policies. Recommended code changes are suggestions only and should be subject to human review for accuracy, applicability, and appropriateness for your environment. This feature should only be used in non-critical, non-production environments that do not contain sensitive data. 
+This feature is currently provided as part of a preview and is subject to our New Relic Experimental policies. Recommended code changes are suggestions only and should be subject to human review for accuracy, applicability, and appropriateness for your environment. This feature should only be used in non-critical, non-production environments that do not contain sensitive data.
 
 This project, its code, and the UX are under heavy development, and should be expected to change. Please take this into consideration when participating in this preview. If you encounter any issues, please report them using Github issues and fill out as much of the issue template as you can so we can improve this tool.
 
@@ -18,7 +20,7 @@ This project, its code, and the UX are under heavy development, and should be ex
 This tool will not interfere with your application's operation, and it doesn't make any changes to your code directly. Here's what happens:
 
 * It analyzes your source code and identifies opportunities to instrument it.
-* It suggests changes to your code that use the New Relic Go agent SDK to capture telemetry data. 
+* It suggests changes to your code that use the New Relic Go agent SDK to capture telemetry data.
 * You review those sugestions that are inserted in a `.diff` file and decide which changes to apply to your source code.
 
 As part of the analysis, this tool may invoke `go get` or other Go language toolchain commands which may modify your `go.mod` file, but not your actual source code.
@@ -30,7 +32,7 @@ As part of the analysis, this tool may invoke `go get` or other Go language tool
 The scope of what this tool can instrument in your application is limited to these actions:
 
  - Capturing errors in any function wrapped or traced by a transaction
- - Tracing locally defined functions that are invoked in the application's main() method with a transaction
+ - Tracing locally defined functions that are invoked in the application's `main()` method with a transaction
  - Tracing async functions and function literals with an async segment
  - Wrapping HTTP handlers
  - Injecting distributed tracing into external traffic
@@ -44,48 +46,30 @@ The scope of what this tool can instrument in your application is limited to the
 
 Before you start the installation steps below, make sure you have a version of Go installed that is within the support window for the current [Go programming language lifecycle](https://endoflife.date/go).
 
-1. Clone this repository to a directory on your system. For example: 
-	```sh
-	git clone .../go-agent-pre-instrumentation
-	```
-2. Go into that directory: 
-	```sh
-	cd go-agent-pre-instrumentation
-	```
-3. Resolve any third-party dependencies: 
-	```sh
-	go mod tidy
-	```
+1. Clone this repository to a directory on your system. For example:
+        ```sh
+        git clone .../go-agent-pre-instrumentation
+        ```
+2. Go into that directory:
+        ```sh
+        cd go-agent-pre-instrumentation
+        ```
+3. Resolve any third-party dependencies:
+        ```sh
+        go mod tidy
+        ```
 ## Generate instrumentation suggestions
- 
-This tool works best with Git. It's a best practice to ensure that your application is on a branch without any unstaged changes before applying any of the generated changes to it. After checking that, follow these steps to generate and apply the changes that install the New Relic Go agent in an application:
 
-1. Go to parser directory: `cd parser`
-2. Run the following CLI command to create a file named `new-relic-instrumentation.diff` in your working directory: 
-	```sh
-	go run . -path ../my-application/` 
-	```
-3. Open the `.diff` file and verify or correct the contents.
-4. When you are satisfied with the instrumentation suggestions, apply the changes:
-	```sh
-	mv new-relic-instrumentation.diff ../my-application/
-	cd ../my-application
-	git apply new-relic-instrumentation.diff
-	```
-
-Once the changes are applied, the application should run with the New Relic Go agent installed. If the agent installation is not working the way you want it to, you can easily recover by using common Git commands. For example, you could try one of the following:
-
-*  Stash the changes with `git stash`
-*  Revert the code to a previous commit
+For detailed instructions on how to generate instrumentation suggestions, see our documentation at [docs.newrelic.com](https://docs/apm/agents/go-agent/installation/install-automation-new-relic-go/#generate-suggestions).
 
 ## Support
 This is an experimental product, and New Relic is not offering official support at the moment. Please create issues in Github if you are encountering a problem that you're unable to resolve. When creating issues, its vital to include as much of the prompted for information as possible. This enables us to get to the root cause of the issue much more quickly. Please also make sure to search existing issues before creating a new one.
 
 ## Contributing
-We encourage your contributions to improve the Go Easy Easy Instrumentation tool! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
-If you have any questions, or to execute our corporate CLA, required if your contribution is on behalf of a company,  please drop us an email at opensource@newrelic.com.
+We encourage your contributions to improve the Go instrumentation tool! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
+If you have any questions, or to execute our corporate CLA, required if your contribution is on behalf of a company, please drop us an email at opensource@newrelic.com.
 
 
 ## License
-Go Easy Instrumentation is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
->The Go Easy Instrumentation tool also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.
+This Go instrumentation tool is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
+>The Go instrumentation tool also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.


### PR DESCRIPTION
This is a PR that changes the naming of the tool from a branded product to a tool. It also removes the steps for generating instrumentation because those are now going to be over in the main docs site.