### PR TITLE
Detect nested and compound call expressions

### DIFF
--- a/end-to-end-tests/unit-tests/expect.ref
+++ b/end-to-end-tests/unit-tests/expect.ref
@@ -1,6 +1,6 @@
 --- a/main.go
 +++ b/main.go
-@@ -4,30 +4,61 @@
+@@ -4,33 +4,69 @@
  	// "context"
  	"context"
  	"fmt"
@@ -8,6 +8,7 @@
  	"unit-tests/pkg1"
  	"unit-tests/pkg2"
  	"unit-tests/pkg3"
+ 	"unit-tests/pkg4"
 +
 +	"github.com/newrelic/go-agent/v3/newrelic"
  )
@@ -71,6 +72,15 @@
 +	fmt.Println(pkg3.CrazyFunction("hello", 42, []string{"foo", "bar"}, map[string]int{"baz": 1, "qux": 2}, struct{ X, Y int }{X: 3, Y: 4}, newrelic.NewContext(context.Background(), nrTxn)))
 +	nrTxn.End()
  
+-	counter := pkg4.NewCounter(pkg3.Concat("hello ", "world")) // Use pkg3.Concat to set the name
+-	counter.GetChild().DecodeSecret()
++	nrTxn = NewRelicAgent.StartTransaction("NewCounter")
++	counter := pkg4.NewCounter(pkg3.Concat("hello ", "world", nrTxn), nrTxn)
++	nrTxn.End() // Use pkg3.Concat to set the name
++	nrTxn = NewRelicAgent.StartTransaction("DecodeSecret")
++	counter.GetChild(nrTxn).DecodeSecret(nrTxn)
++	nrTxn.End()
++
 +	NewRelicAgent.Shutdown(5 * time.Second)
  }
 --- a/pkg1/pkg1.go
@@ -399,8 +409,8 @@
 +		result = Concat(result, fmt.Sprintf("%s%d", k, v), nrTxn)
  	}
  
--	result = Concat(result, fmt.Sprintf("%d%d", e.X, e.Y))
-+	result = Concat(result, fmt.Sprintf("%d%d", e.X, e.Y), nrTxn)
+-	result = Concat(result, Concat(" ", "%"))
++	result = Concat(result, Concat(" ", "%", nrTxn), nrTxn)
  
  	return result, nil
  }
@@ -443,3 +453,51 @@
  }
  
  func TestThingWithContext(t *testing.T) {
+--- a/pkg4/obj.go
++++ b/pkg4/obj.go
+@@ -3,17 +3,22 @@
+ import (
+ 	"encoding/base64"
+ 	"fmt"
++
++	"github.com/newrelic/go-agent/v3/newrelic"
+ )
+ 
+ type Child struct {
+ 	secret string
+ }
+ 
+-func (c *Child) DecodeSecret() string {
++func (c *Child) DecodeSecret(nrTxn *newrelic.Transaction) string {
++	defer nrTxn.StartSegment("DecodeSecret").End()
++
+ 	// Decode the base64 encoded secret
+ 	decodedBytes, err := base64.StdEncoding.DecodeString(c.secret)
+ 	if err != nil {
+ 		// Handle error in decoding
++		nrTxn.NoticeError(err)
+ 		return "Error decoding secret: " + err.Error()
+ 	}
+ 	// Return the decoded string
+@@ -26,7 +21,9 @@
+ 	child *Child // Embedding Child struct to demonstrate composition
+ }
+ 
+-func NewCounter(name string) *Counter {
++func NewCounter(name string, nrTxn *newrelic.Transaction) *Counter {
++	defer nrTxn.StartSegment("NewCounter").End()
++
+ 	return &Counter{
+ 		name:  name,
+ 		count: 0, // Initialize count to 0
+@@ -44,7 +41,9 @@
+ 	return e.count
+ }
+ 
+-func (e *Counter) GetChild() *Child {
++func (e *Counter) GetChild(nrTxn *newrelic.Transaction) *Child {
++	defer nrTxn.StartSegment("GetChild").End()
++
+ 	return e.child
+ }
+

--- a/end-to-end-tests/unit-tests/main.go
+++ b/end-to-end-tests/unit-tests/main.go
@@ -7,6 +7,7 @@ import (
 	"unit-tests/pkg1"
 	"unit-tests/pkg2"
 	"unit-tests/pkg3"
+	"unit-tests/pkg4"
 )
 
 func main() {
@@ -30,4 +31,6 @@ func main() {
 	fmt.Println(pkg3.UnrulyFunction("hello", "world", context.Background()))
 	fmt.Println(pkg3.CrazyFunction("hello", 42, []string{"foo", "bar"}, map[string]int{"baz": 1, "qux": 2}, struct{ X, Y int }{X: 3, Y: 4}, context.Background()))
 
+	counter := pkg4.NewCounter(pkg3.Concat("hello ", "world")) // Use pkg3.Concat to set the name
+	counter.GetChild().DecodeSecret()
 }

--- a/end-to-end-tests/unit-tests/pkg3/pkg3.go
+++ b/end-to-end-tests/unit-tests/pkg3/pkg3.go
@@ -91,7 +91,7 @@ func CrazyFunction(a string, b int, c []string, d map[string]int, e struct{ X, Y
 		result = Concat(result, fmt.Sprintf("%s%d", k, v))
 	}
 
-	result = Concat(result, fmt.Sprintf("%d%d", e.X, e.Y))
+	result = Concat(result, Concat(" ", "%"))
 
 	return result, nil
 }

--- a/end-to-end-tests/unit-tests/pkg4/obj.go
+++ b/end-to-end-tests/unit-tests/pkg4/obj.go
@@ -1,0 +1,57 @@
+package pkg4
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+type Child struct {
+	secret string
+}
+
+func (c *Child) DecodeSecret() string {
+	// Decode the base64 encoded secret
+	decodedBytes, err := base64.StdEncoding.DecodeString(c.secret)
+	if err != nil {
+		// Handle error in decoding
+		return "Error decoding secret: " + err.Error()
+	}
+	// Return the decoded string
+	return string(decodedBytes)
+}
+
+type Counter struct {
+	count int
+	name  string
+	child *Child // Embedding Child struct to demonstrate composition
+}
+
+func NewCounter(name string) *Counter {
+	return &Counter{
+		name:  name,
+		count: 0, // Initialize count to 0
+		child: &Child{
+			base64.StdEncoding.EncodeToString([]byte("Hi, I am a secret. Don't look at me!")),
+		},
+	}
+}
+
+func (e *Counter) Increment() {
+	e.count++
+}
+
+func (e *Counter) GetCount() int {
+	return e.count
+}
+
+func (e *Counter) GetChild() *Child {
+	return e.child
+}
+
+func (e *Counter) Name() string {
+	return e.name
+}
+
+func (e *Counter) String() string {
+	return fmt.Sprintf("%s: %d", e.name, e.count)
+}

--- a/parser/manager.go
+++ b/parser/manager.go
@@ -285,20 +285,25 @@ func (m *InstrumentationManager) findInvocationInfo(node dst.Node, state *traces
 						decl:         pkg.tracedFuncs[fun.Name].body,
 					})
 				}
-				return true
 			case *dst.SelectorExpr:
 				// Handle selector expressions like `f().g().x()`
-				path := resolvePath(fun.Sel.Path, m.getPackageName(), "")
+				pkgName := util.PackagePath(fun.Sel, m.getDecoratorPackage())
+				path := resolvePath(pkgName, m.getPackageName(), "")
 				pkg, ok := m.packages[path]
-				if ok && pkg.tracedFuncs[fun.Sel.Name] != nil {
+				functionName := fun.Sel.Name
+
+				// Check if the function is defined in a package of this application.
+				// If true, tracing can be passed into it.
+				if ok && pkg.tracedFuncs[functionName] != nil {
 					invInfo = append(invInfo, &invocationInfo{
-						functionName: fun.Sel.Name,
+						functionName: functionName,
 						packageName:  path,
 						call:         call,
-						decl:         pkg.tracedFuncs[fun.Sel.Name].body,
+						decl:         pkg.tracedFuncs[functionName].body,
 					})
 				}
 			}
+			return true
 		}
 		return true
 	})

--- a/parser/manager.go
+++ b/parser/manager.go
@@ -239,10 +239,10 @@ func (m *InstrumentationManager) getInvocationInfoFromCall(call *dst.CallExpr, f
 	return nil
 }
 
-// findInvocationInfo recursively searches for a call expression and
-// returns a collection of data about the discovered function call if it was defined
-// in the scope of this application. If the expression passed does not contain a valid function
-// call, this method will return nil.
+// findInvocationInfo post order traverses the node and searches for function calls that are defined
+// within the current application and is reachable by tracing. This method
+// returns a slice of data about the discovered function call(s) that can have tracing propagated
+// to them automatically. If no matches are found, an empty list will be returned.
 //
 // The node passed is a dst node that you want to search for a function call in.
 // The state passed is the current state of the application, and is used to resolve function literals.
@@ -251,8 +251,13 @@ func (m *InstrumentationManager) getInvocationInfoFromCall(call *dst.CallExpr, f
 // function calls in unit tests becasue the package linking is not handled the same way as in the main application.
 //
 // If the node does not contain a function call made to a function declared in this application, this method will return nil.
-func (m *InstrumentationManager) findInvocationInfo(node dst.Node, state *tracestate.State) *invocationInfo {
-	var invInfo *invocationInfo
+//
+// Possible cases:
+// 1. A function call to a function in the current package: f()
+// 2. A function call chain of functions: f().g().x()
+// 3. A function call containing nested function calls: f(g(x()))
+func (m *InstrumentationManager) findInvocationInfo(node dst.Node, state *tracestate.State) []*invocationInfo {
+	invInfo := []*invocationInfo{}
 
 	dst.Inspect(node, func(n dst.Node) bool {
 		switch v := n.(type) {
@@ -262,30 +267,38 @@ func (m *InstrumentationManager) findInvocationInfo(node dst.Node, state *traces
 			call := v
 			_, ok := state.GetFuncLitVariable(m.getDecoratorPackage(), call.Fun)
 			if ok {
-				invInfo = &invocationInfo{
+				invInfo = append(invInfo, &invocationInfo{
 					functionName: "Function Literal",
 					packageName:  m.getPackageName(),
 					call:         call,
-				}
+				})
 			}
-			functionCallIdent, ok := call.Fun.(*dst.Ident)
-			if !ok {
+			switch fun := call.Fun.(type) {
+			case *dst.Ident:
+				path := resolvePath(fun.Path, m.getPackageName(), "")
+				pkg, ok := m.packages[path]
+				if ok && pkg.tracedFuncs[fun.Name] != nil {
+					invInfo = append(invInfo, &invocationInfo{
+						functionName: fun.Name,
+						packageName:  path,
+						call:         call,
+						decl:         pkg.tracedFuncs[fun.Name].body,
+					})
+				}
 				return true
-			}
-
-			path := resolvePath(functionCallIdent.Path, m.getPackageName(), "")
-			pkg, ok := m.packages[path]
-			if ok && pkg.tracedFuncs[functionCallIdent.Name] != nil {
-				invInfo = &invocationInfo{
-					functionName: functionCallIdent.Name,
-					packageName:  path,
-					call:         call,
-					decl:         pkg.tracedFuncs[functionCallIdent.Name].body,
+			case *dst.SelectorExpr:
+				// Handle selector expressions like `f().g().x()`
+				path := resolvePath(fun.Sel.Path, m.getPackageName(), "")
+				pkg, ok := m.packages[path]
+				if ok && pkg.tracedFuncs[fun.Sel.Name] != nil {
+					invInfo = append(invInfo, &invocationInfo{
+						functionName: fun.Sel.Name,
+						packageName:  path,
+						call:         call,
+						decl:         pkg.tracedFuncs[fun.Sel.Name].body,
+					})
 				}
-				return false
 			}
-
-			return true
 		}
 		return true
 	})

--- a/parser/tracing.go
+++ b/parser/tracing.go
@@ -109,10 +109,14 @@ func TraceFunction(manager *InstrumentationManager, node dst.Node, tracing *trac
 
 			rootPkg := manager.currentPackage
 			tracableInvocations := manager.findInvocationInfo(v, tracing)
+			transactionCreatedForStatement := false // prevent multiple transactions from being created for the same statement
 
 			// inv info will be nil if the function is not declared in this application
 			for _, invInfo := range tracableInvocations {
-				tracing.WrapWithTransaction(c, invInfo.functionName, codegen.DefaultTransactionVariable) // if a trasaction needs to be created, it will be created here
+				if !transactionCreatedForStatement {
+					tracing.WrapWithTransaction(c, invInfo.functionName, codegen.DefaultTransactionVariable) // if a trasaction needs to be created, it will be created here
+					transactionCreatedForStatement = true
+				}
 				childState, tracingImport := tracing.AddToCall(manager.getDecoratorPackage(), invInfo.call, false)
 				manager.addImport(tracingImport)
 				TopLevelFunctionChanged = true

--- a/parser/tracing.go
+++ b/parser/tracing.go
@@ -73,8 +73,8 @@ func TraceFunction(manager *InstrumentationManager, node dst.Node, tracing *trac
 
 			default:
 				rootPkg := manager.currentPackage
-				invInfo := manager.findInvocationInfo(v.Call, tracing)
-				if invInfo != nil {
+				tracableInvocations := manager.findInvocationInfo(v.Call, tracing)
+				for _, invInfo := range tracableInvocations {
 					childState, tracingImport := tracing.AddToCall(manager.getDecoratorPackage(), v.Call, true)
 					manager.addImport(tracingImport)
 					c.Replace(v)
@@ -108,10 +108,10 @@ func TraceFunction(manager *InstrumentationManager, node dst.Node, tracing *trac
 			}
 
 			rootPkg := manager.currentPackage
-			invInfo := manager.findInvocationInfo(v, tracing)
+			tracableInvocations := manager.findInvocationInfo(v, tracing)
 
 			// inv info will be nil if the function is not declared in this application
-			if invInfo != nil {
+			for _, invInfo := range tracableInvocations {
 				tracing.WrapWithTransaction(c, invInfo.functionName, codegen.DefaultTransactionVariable) // if a trasaction needs to be created, it will be created here
 				childState, tracingImport := tracing.AddToCall(manager.getDecoratorPackage(), invInfo.call, false)
 				manager.addImport(tracingImport)


### PR DESCRIPTION
 Can now detect and trace:

```go
a().b().c()
```

```go
a(b(c()))
```